### PR TITLE
Allows multiple global dependencies

### DIFF
--- a/async-define.js
+++ b/async-define.js
@@ -55,28 +55,31 @@
             params = [],
             dependencies_satisfied = true,
             dependency_name,
-            result;
+            result,
+            config_dependencies_iterator = 0,
+            dependencies_iterator = 0,
+            config_dependencies_index = -1;
 
         // config dependecies
         if(_define.prototype.config_dependencies && _define.prototype.config_dependencies.constructor === Array) {
             var config_dependencies = _define.prototype.config_dependencies || [];
 
-            var config_dependencies_index = -1;
             var config_dependencies_size = config_dependencies.length;
-            for(var config_dependencies_iterator = 0; config_dependencies_iterator < config_dependencies_size; config_dependencies_iterator++) {
+            for(; config_dependencies_iterator < config_dependencies_size; config_dependencies_iterator++) {
                 if(name == config_dependencies[config_dependencies_iterator]) {
                     config_dependencies_index = config_dependencies_iterator;
                 }
             }
             if(config_dependencies_index != -1) {
-               config_dependencies.splice(config_dependencies_index, 1);
+                config_dependencies.splice(config_dependencies_index, 1)
+            } else {
+                dependencies = dependencies.concat(config_dependencies);
             }
-            dependencies = dependencies.concat(config_dependencies);
         }
         debug && console.log('registering', name);
 
         // find params
-        for (var dependencies_iterator=0; dependencies_iterator < dependencies.length; dependencies_iterator++) {
+        for (; dependencies_iterator < dependencies.length; dependencies_iterator++) {
             dependency_name = dependencies[dependencies_iterator];
             debug && console.log('dependency found on', dependency_name);
 


### PR DESCRIPTION
Fix the problem when we define more than one dependencies using `define.prototype.config_dependencies`
